### PR TITLE
[ua-nodeset] Avoid checking Conan version when testing a package

### DIFF
--- a/recipes/ua-nodeset/all/test_package/conanfile.py
+++ b/recipes/ua-nodeset/all/test_package/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
-from conan import ConanFile, conan_version
+from conan import ConanFile
+from conan.tools.files import load, save
 
 
 class TestPackageConan(ConanFile):
@@ -10,15 +11,14 @@ class TestPackageConan(ConanFile):
     def layout(self):
         pass
 
+    def generate(self):
+        nodeset_dir = self.dependencies["ua-nodeset"].conf_info.get("user.ua-nodeset:nodeset_dir")
+        save(self, "nodeset_dir", nodeset_dir)
+
     def requirements(self):
         self.requires(self.tested_reference_str)
 
     def test(self):
-        if conan_version.major >= 2:
-            nodeset_dir = self.dependencies["ua-nodeset"].conf_info.get("user.ua-nodeset:nodeset_dir")
-        else:
-            # TODO: to remove in conan v2
-            nodeset_dir = self.deps_user_info["ua-nodeset"].nodeset_dir
-
+        nodeset_dir = load(self, "nodeset_dir")
         test_path = os.path.join(nodeset_dir, "PLCopen")
         assert os.path.exists(test_path)


### PR DESCRIPTION
Instead of using Conan version to check and run a specific code, let's adopt something straightforward and more used in CCI: Store the dependency value in a file, then, restore it when running test() method. 


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
