### PR TITLE
New/zenoh c

### DIFF
--- a/recipes/zenoh-c/all/conandata.yml
+++ b/recipes/zenoh-c/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.10.1-rc":
+    url: "https://github.com/eclipse-zenoh/zenoh-c/archive/refs/tags/0.10.1-rc.tar.gz"
+    sha256: "9fb703eff79b7c1ef216f411dadcb7f0132c8ba665823b5a8252b467b4937438"

--- a/recipes/zenoh-c/all/conanfile.py
+++ b/recipes/zenoh-c/all/conanfile.py
@@ -12,6 +12,8 @@ class ZenohCConan(ConanFile):
     license = "EPL-2.0 OR Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/eclipse-zenoh/zenoh-c"
+    topics = ("networking", "pub-sub", "messaging", "robotics", "ros2", "iot", "edge-computing", "micro-controllers")
+
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {

--- a/recipes/zenoh-c/all/conanfile.py
+++ b/recipes/zenoh-c/all/conanfile.py
@@ -1,0 +1,103 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv, Environment
+from conan.tools.files import get, copy, replace_in_file, save, rmdir, rm, rename
+
+
+class ZenohCConan(ConanFile):
+    name = "zenoh-c"
+    description = "C API for Zenoh: a pub/sub/query protocol unifying data in motion, data at rest and computations"
+    license = "EPL-2.0 OR Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/eclipse-zenoh/zenoh-c"
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": True,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        pass
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+        self.tool_requires("rust/1.76.0")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        venv = VirtualBuildEnv(self)
+        venv.generate()
+
+        tc = CMakeToolchain(self)
+        tc.variables["ZENOHC_INSTALL_STATIC_LIBRARY"] = not self.options.shared
+        tc.generate()
+
+        # Don't add the Cargo dependencies to a global Cargo cache
+        env = Environment()
+        env.define_path("CARGO_HOME", os.path.join(self.build_folder, "cargo"))
+        env.vars(self).save_script("cargo_home_env")
+
+    def _patch_sources(self):
+        # Cargo channels are only applicable when Rust has been installed via rustup
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                        "+${ZENOHC_CARGO_CHANNEL}", "")
+        # Disable building of examples and tests
+        save(self, os.path.join(self.source_folder, "examples", "CMakeLists.txt"), "")
+        save(self, os.path.join(self.source_folder, "tests", "CMakeLists.txt"), "")
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    @property
+    def _lib_name(self):
+        if self.settings.build_type == "Debug":
+            return "zenohcd"
+        return "zenohc"
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        if not self.options.shared:
+            rm(self, "*.so", os.path.join(self.package_folder, "lib"))
+            rm(self, "*.dylib", os.path.join(self.package_folder, "lib"))
+            rm(self, "*.dll", os.path.join(self.package_folder, "bin"))
+        if self.settings.os == "Windows" and self.options.shared:
+            rename(self, os.path.join(self.package_folder, "bin", f"{self._lib_name}.dll.lib"),
+                   os.path.join(self.package_folder, "lib", f"{self._lib_name}.lib"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "zenohc")
+        self.cpp_info.set_property("cmake_target_name", "zenohc::lib")
+        self.cpp_info.set_property("cmake_target_aliases", [f"zenohc::{'shared' if self.options.shared else 'static'}"])
+
+        self.cpp_info.libs = [self._lib_name]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["dl", "m", "pthread", "rt"])

--- a/recipes/zenoh-c/all/conanfile.py
+++ b/recipes/zenoh-c/all/conanfile.py
@@ -8,6 +8,7 @@ from conan.tools.files import get, copy, replace_in_file, save, rmdir, rm, renam
 
 class ZenohCConan(ConanFile):
     name = "zenoh-c"
+    version = "0.10.1-rc"
     description = "C API for Zenoh: a pub/sub/query protocol unifying data in motion, data at rest and computations"
     license = "EPL-2.0 OR Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/zenoh-c/all/conanfile.py
+++ b/recipes/zenoh-c/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv, Environment
 from conan.tools.files import get, copy, replace_in_file, save, rmdir, rm, rename
@@ -32,6 +33,18 @@ class ZenohCConan(ConanFile):
         "ZENOHC_CARGO_FLAGS": "",
     }
 
+    @property
+    def _supported_platforms(self):
+        return [
+            ("Windows", "x86_64"),
+            ("Linux", "x86_64"),
+            ("Linux", "armv6"),
+            ("Linux", "armv7hf"),
+            ("Linux", "armv8"),
+            ("Macos", "x86_64"),
+            ("Macos", "armv8"),
+        ]
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -44,6 +57,10 @@ class ZenohCConan(ConanFile):
 
     def layout(self):
         cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        if (self.settings.os, self.settings.arch) not in self._supported_platforms:
+            raise ConanInvalidConfiguration("{}/{} combination is not supported".format(self.settings.os, self.settings.arch))
 
     def requirements(self):
         pass

--- a/recipes/zenoh-c/all/conanfile.py
+++ b/recipes/zenoh-c/all/conanfile.py
@@ -20,10 +20,16 @@ class ZenohCConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "ZENOHC_BUILD_WITH_LOGGER_AUTOINIT":[True, False],
+        "ZENOHC_BUILD_WITH_SHARED_MEMORY":[True, False],
+        "ZENOHC_CARGO_FLAGS": ["ANY"],
     }
     default_options = {
         "shared": True,
         "fPIC": True,
+        "ZENOHC_BUILD_WITH_LOGGER_AUTOINIT": True,
+        "ZENOHC_BUILD_WITH_SHARED_MEMORY": True,
+        "ZENOHC_CARGO_FLAGS": "",
     }
 
     def config_options(self):

--- a/recipes/zenoh-c/all/conanfile.py
+++ b/recipes/zenoh-c/all/conanfile.py
@@ -25,7 +25,7 @@ class ZenohCConan(ConanFile):
         "ZENOHC_CARGO_FLAGS": ["ANY"],
     }
     default_options = {
-        "shared": True,
+        "shared": False,
         "fPIC": True,
         "ZENOHC_BUILD_WITH_LOGGER_AUTOINIT": True,
         "ZENOHC_BUILD_WITH_SHARED_MEMORY": True,

--- a/recipes/zenoh-c/all/conanfile.py
+++ b/recipes/zenoh-c/all/conanfile.py
@@ -9,7 +9,6 @@ from conan.tools.files import get, copy, replace_in_file, save, rmdir, rm, renam
 
 class ZenohCConan(ConanFile):
     name = "zenoh-c"
-    version = "0.10.1-rc"
     description = "C API for Zenoh: a pub/sub/query protocol unifying data in motion, data at rest and computations"
     license = "EPL-2.0 OR Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/zenoh-c/all/conanfile.py
+++ b/recipes/zenoh-c/all/conanfile.py
@@ -110,3 +110,7 @@ class ZenohCConan(ConanFile):
         self.cpp_info.libs = [self._lib_name]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["dl", "m", "pthread", "rt"])
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["bcrypt", "crypt32", "iphlpapi", "ncrypt", "ntdll", "runtimeobject", "secur32", "userenv", "ws2_32"])
+        elif self.settings.os == "Macos":
+            self.cpp_info.frameworks.extend(["Foundation", "Security"])

--- a/recipes/zenoh-c/all/test_package/CMakeLists.txt
+++ b/recipes/zenoh-c/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(zenohc REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE zenohc::lib)

--- a/recipes/zenoh-c/all/test_package/conanfile.py
+++ b/recipes/zenoh-c/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/zenoh-c/all/test_package/test_package.c
+++ b/recipes/zenoh-c/all/test_package/test_package.c
@@ -1,0 +1,61 @@
+// https://github.com/eclipse-zenoh/zenoh-c/blob/0.10.1-rc/examples/z_info.c
+
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+
+#include <zenoh.h>
+
+#include <stdio.h>
+
+void print_zid(const z_id_t *id, void *ctx) {
+    for (int i = 0; i < 16; i++) {
+        printf("%02x", id->id[i]);
+    }
+    printf("\n");
+}
+
+int main(int argc, char **argv) {
+    z_owned_config_t config = z_config_default();
+    if (argc > 1) {
+        if (zc_config_insert_json(z_loan(config), Z_CONFIG_CONNECT_KEY, argv[1]) < 0) {
+            printf(
+                "Couldn't insert value `%s` in configuration at `%s`. This is likely because `%s` expects a "
+                "JSON-serialized list of strings\n",
+                argv[1], Z_CONFIG_CONNECT_KEY, Z_CONFIG_CONNECT_KEY);
+            exit(-1);
+        }
+    }
+
+    printf("Opening session...\n");
+    z_owned_session_t s = z_open(z_move(config));
+    if (!z_check(s)) {
+        printf("Unable to open session!\n");
+        exit(-1);
+    }
+
+    z_id_t self_id = z_info_zid(z_loan(s));
+    printf("own id: ");
+    print_zid(&self_id, NULL);
+
+    printf("routers ids:\n");
+    z_owned_closure_zid_t callback = z_closure(print_zid);
+    z_info_routers_zid(z_loan(s), z_move(callback));
+
+    // `callback` has been `z_move`d just above, so it's safe to reuse the variable,
+    // we'll just have to make sure we `z_move` it again to avoid mem-leaks.
+    printf("peers ids:\n");
+    z_owned_closure_zid_t callback2 = z_closure(print_zid);
+    z_info_peers_zid(z_loan(s), z_move(callback2));
+
+    z_close(z_move(s));
+}

--- a/recipes/zenoh-c/config.yml
+++ b/recipes/zenoh-c/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.10.1-rc":
+    folder: all


### PR DESCRIPTION
- ~Add default version~ Reverted due to CCI linting rules
- Add system libraries for static build on Mac and Windows (verified locally on Mac, haven't tested on Windows)
- Expose Zenoh-C's build options related to Zenoh features
- Build static lib by default (CCI rule)
- Filter supported OS/arch combination (Zenoh Team requested to limit supported targets to the ones in upstream releases)