### PR TITLE
Don't use PkgConfig helper

### DIFF
--- a/recipes/glib/all/test_package/conanfile.py
+++ b/recipes/glib/all/test_package/conanfile.py
@@ -2,7 +2,8 @@ from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake, CMakeDeps, CMakeToolchain
 from conan.tools.env import Environment, VirtualBuildEnv, VirtualRunEnv
-from conan.tools.gnu import PkgConfig, PkgConfigDeps
+from conan.tools.gnu import PkgConfigDeps
+import io
 import os
 
 
@@ -54,6 +55,6 @@ class TestPackageConan(ConanFile):
             self.run(bin_path, env="conanrun")
 
             if self.settings.os != "Windows":
-                pkg_config = PkgConfig(self, "gio-2.0", pkg_config_path=self.generators_folder)
-                gdbus_codegen = pkg_config.variables["gdbus_codegen"]
-                self.run(f"{gdbus_codegen} -h")
+                mybuf = io.StringIO()
+                self.run(f"PKG_CONFIG_PATH={self.generators_folder} pkgconf --variable=gdbus_codegen gio-2.0", mybuf, env="conanbuild")
+                self.run(f"{mybuf.getvalue().strip()} -h")


### PR DESCRIPTION
because pkg-config is not installed on macos runners

@valgur 


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
