### PR TITLE
[poppler] fix freetype patch error and libtiff build error 

### DIFF
--- a/recipes/poppler/all/conanfile.py
+++ b/recipes/poppler/all/conanfile.py
@@ -134,7 +134,7 @@ class PopplerConan(ConanFile):
         if self.options.with_tiff:
             self.requires("libtiff/4.6.0")
         if self.options.splash:
-            self.requires("boost/1.85.0")
+            self.requires("boost/1.86.0")
         if self.options.with_libcurl:
             # https://gitlab.freedesktop.org/poppler/poppler/-/blob/poppler-23.11.0/poppler/CurlCachedFile.h#L18
             self.requires("libcurl/[>=7.78 <9]", transitive_headers=True, transitive_libs=True)

--- a/recipes/poppler/all/conanfile.py
+++ b/recipes/poppler/all/conanfile.py
@@ -272,8 +272,6 @@ class PopplerConan(ConanFile):
         # Ignore package versions in find_soft_mandatory_package()
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                         "find_package(${_package_name} ${_package_version})", "find_package(${_package_name})")
-        # replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-        #                 "FREETYPE ${FREETYPE_VERSION} REQUIRED", "FREETYPE REQUIRED")
 
     def build(self):
         self._patch_sources()

--- a/recipes/poppler/all/conanfile.py
+++ b/recipes/poppler/all/conanfile.py
@@ -14,6 +14,7 @@ required_conan_version = ">=1.56.0 <2 || >=2.0.6"
 
 class PopplerConan(ConanFile):
     name = "poppler"
+    version = "24.05.0"
     description = "Poppler is a PDF rendering library based on the xpdf-3.0 code base"
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/poppler/all/conanfile.py
+++ b/recipes/poppler/all/conanfile.py
@@ -313,7 +313,7 @@ class PopplerConan(ConanFile):
         if self.options.with_nss:
             self.cpp_info.components["libpoppler"].requires.append("nss::nss")
         if self.options.with_tiff:
-            self.cpp_info.components["libpoppler"].requires.append("libtiff::tiff")
+            self.cpp_info.components["libpoppler"].requires.append("libtiff::libtiff")
         if self.options.with_libcurl:
             self.cpp_info.components["libpoppler"].requires.append("libcurl::libcurl")
         if self.options.with_zlib:

--- a/recipes/poppler/all/conanfile.py
+++ b/recipes/poppler/all/conanfile.py
@@ -106,7 +106,7 @@ class PopplerConan(ConanFile):
     def requirements(self):
         self.requires("poppler-data/0.4.11", transitive_headers=True, transitive_libs=True)
         # https://gitlab.freedesktop.org/poppler/poppler/-/blob/poppler-22.04.0/splash/SplashFTFont.h#L30
-        self.requires("freetype/2.13.2", transitive_headers=True, transitive_libs=True)
+        self.requires("freetype/2.13.3", transitive_headers=True, transitive_libs=True)
         if self.options.get_safe("with_libiconv"):
             self.requires("libiconv/1.17")
         if self.options.fontconfiguration == "fontconfig":
@@ -272,8 +272,8 @@ class PopplerConan(ConanFile):
         # Ignore package versions in find_soft_mandatory_package()
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                         "find_package(${_package_name} ${_package_version})", "find_package(${_package_name})")
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                        "FREETYPE ${FREETYPE_VERSION} REQUIRED", "FREETYPE REQUIRED")
+        # replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+        #                 "FREETYPE ${FREETYPE_VERSION} REQUIRED", "FREETYPE REQUIRED")
 
     def build(self):
         self._patch_sources()


### PR DESCRIPTION
### Summary
Changes to recipe:  **poppler/24.05**

#### Motivation
fix ci errors to be able to see remaining linker errors

#### Details
- fix link dependency 4 libtiff
- remove patch for cmake for freetype version
- update freetype to latest bugfix version
- update boost to latest version


---
- [x ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x ] Tested locally with at least one configuration using a recent version of Conan
